### PR TITLE
Move description to top level of functions

### DIFF
--- a/component.json
+++ b/component.json
@@ -20,8 +20,8 @@
     "httpRequestTrigger": {
       "main": "./lib/triggers/httpRequestTrigger.js",
       "title": "HTTP request",
+      "description": "Will send a GET/POST/PUT/DELETE HTTP request and parse the response back to the flow",
       "help": {
-        "description": "Will send a GET/POST/PUT/DELETE HTTP request and parse the response back to the flow",
         "link": "/components/rest-api/index.html#http-request"
       },
       "type": "polling",
@@ -82,8 +82,8 @@
     "httpRequestAction": {
       "main": "./lib/actions/httpRequestAction.js",
       "title": "HTTP request",
+      "description": "Will send a GET/POST/PUT/DELETE HTTP request and parse the response back to the flow",
       "help": {
-        "description": "Will send a GET/POST/PUT/DELETE HTTP request and parse the response back to the flow",
         "link": "/components/rest-api/index.html#http-request-1"
       },
       "metadata": {


### PR DESCRIPTION
Actions and triggers in all other components have description at the top-level. This component, however has a "help" key with "description" contained inside. I have moved this to the top level to maintain consistency among components. I have left the "help" key for now, although I don't know what it is used for...